### PR TITLE
Overload source to accept any combination of factors

### DIFF
--- a/src/AsyncWriterResult/Library.fs
+++ b/src/AsyncWriterResult/Library.fs
@@ -267,9 +267,13 @@ let asyncWriterResult = AsyncWriterResultBuilder()
 [<AutoOpen>]
 module AsyncWriterResultBuilderExtensions =
     type AsyncWriterResultBuilder with
-        member __.Source(x: Writer<'w, Result<'a, 'b>>) = x |> Async.retn
-        member __.Source(x: Async<Result<'a, 'b>>) = x |> Async.map Writer.retn
-        member __.Source(x: Async<Writer<'w, 't>>) = x |> AsyncWriter.map Result.retn
         member __.Source(x: Result<'a, 'b>) = x |> AsyncWriter.retn
         member __.Source(x: Writer<'w, 't>) = x |> Writer.map Ok |> Async.retn
         member __.Source(x: Async<'t>) = x |> Async.map WriterResult.retn
+
+[<AutoOpen>]
+module AsyncWriterResultBuilderExtensionsHighPriority =
+    type AsyncWriterResultBuilder with
+        member __.Source(x: Writer<'w, Result<'a, 'b>>) = x |> Async.retn
+        member __.Source(x: Async<Result<'a, 'b>>) = x |> Async.map Writer.retn
+        member __.Source(x: Async<Writer<'w, 't>>) = x |> AsyncWriter.map Result.retn

--- a/src/AsyncWriterResult/TaskWriterResult.fs
+++ b/src/AsyncWriterResult/TaskWriterResult.fs
@@ -35,6 +35,8 @@ module TaskWriter =
 
     let retn a = Writer.retn a |> Task.retn
 
+    let map f = f |> Writer.map |> Task.map
+
 
 
 
@@ -110,5 +112,16 @@ module TaskWriterResult =
         member __.ReturnFrom(m: Task<Writer<'w, Result<'a, 'b>>>) = m
         member __.Bind(m, f) = bind f m
         member __.Zero() = __.Return()
+        member __.Source(x: Task<Writer<'w, Result<'a, 'b>>>) = x
 
     let taskWriterResult = TaskWriterResultBuilder()
+
+    [<AutoOpen>]
+    module TaskWriterResultBuilderExtensions =
+        type TaskWriterResultBuilder with
+            member __.Source(x: Writer<'w, Result<'a, 'b>>) = x |> Task.retn
+            member __.Source(x: Task<Result<'a, 'b>>) = x |> Task.map Writer.retn
+            member __.Source(x: Task<Writer<'w, 't>>) = x |> TaskWriter.map Result.retn
+            member __.Source(x: Result<'a, 'b>) = x |> TaskWriter.retn
+            member __.Source(x: Writer<'w, 't>) = x |> Writer.map Ok |> Task.retn
+            member __.Source(x: Task<'t>) = x |> Task.map WriterResult.retn

--- a/src/AsyncWriterResult/TaskWriterResult.fs
+++ b/src/AsyncWriterResult/TaskWriterResult.fs
@@ -119,9 +119,13 @@ module TaskWriterResult =
     [<AutoOpen>]
     module TaskWriterResultBuilderExtensions =
         type TaskWriterResultBuilder with
-            member __.Source(x: Writer<'w, Result<'a, 'b>>) = x |> Task.retn
-            member __.Source(x: Task<Result<'a, 'b>>) = x |> Task.map Writer.retn
-            member __.Source(x: Task<Writer<'w, 't>>) = x |> TaskWriter.map Result.retn
             member __.Source(x: Result<'a, 'b>) = x |> TaskWriter.retn
             member __.Source(x: Writer<'w, 't>) = x |> Writer.map Ok |> Task.retn
             member __.Source(x: Task<'t>) = x |> Task.map WriterResult.retn
+
+    [<AutoOpen>]
+    module TaskWriterResultBuilderExtensionsHighPriority =
+        type TaskWriterResultBuilder with
+            member __.Source(x: Writer<'w, Result<'a, 'b>>) = x |> Task.retn
+            member __.Source(x: Task<Result<'a, 'b>>) = x |> Task.map Writer.retn
+            member __.Source(x: Task<Writer<'w, 't>>) = x |> TaskWriter.map Result.retn


### PR DESCRIPTION
These changes update the `WriterResult`, `AsyncWriterResult` and `TaskWriterResult` CEs to support returning any combination of factors. E.g. using `let!`  within a `AsyncWriterResult` CE will accept an `AsyncResult` or a `Writer`.

- [x] Need to test each combination in case 1 layer and 2 layer sources need to be in separate modules for type inference.