### PR TITLE
Accept task or async

### DIFF
--- a/src/AsyncWriterResult/Library.fs
+++ b/src/AsyncWriterResult/Library.fs
@@ -1,6 +1,8 @@
 ﻿[<AutoOpen>]
 module AsyncWriterResult
 
+open System.Threading.Tasks
+
 
 module Async =
 
@@ -261,6 +263,7 @@ type AsyncWriterResultBuilder() =
     member __.Bind(m, f) = AsyncWriterResult.bind f m
     member __.Zero() = __.Return()
     member __.Source(x: Async<Writer<'w, Result<'a, 'b>>>) = x
+    member __.Source(x: Task<Writer<'w, Result<'a, 'b>>>) = x |> Async.AwaitTask
 
 let asyncWriterResult = AsyncWriterResultBuilder()
 
@@ -270,6 +273,7 @@ module AsyncWriterResultBuilderExtensions =
         member __.Source(x: Result<'a, 'b>) = x |> AsyncWriter.retn
         member __.Source(x: Writer<'w, 't>) = x |> Writer.map Ok |> Async.retn
         member __.Source(x: Async<'t>) = x |> Async.map WriterResult.retn
+        member __.Source(x: Task<'t>) = x |> Async.AwaitTask |> Async.map WriterResult.retn
 
 [<AutoOpen>]
 module AsyncWriterResultBuilderExtensionsHighPriority =
@@ -277,3 +281,5 @@ module AsyncWriterResultBuilderExtensionsHighPriority =
         member __.Source(x: Writer<'w, Result<'a, 'b>>) = x |> Async.retn
         member __.Source(x: Async<Result<'a, 'b>>) = x |> Async.map Writer.retn
         member __.Source(x: Async<Writer<'w, 't>>) = x |> AsyncWriter.map Result.retn
+        member __.Source(x: Task<Result<'a, 'b>>) = x |> Async.AwaitTask |> Async.map Writer.retn
+        member __.Source(x: Task<Writer<'w, 't>>) = x |> Async.AwaitTask |> AsyncWriter.map Result.retn

--- a/src/AsyncWriterResult/TaskWriterResult.fs
+++ b/src/AsyncWriterResult/TaskWriterResult.fs
@@ -113,6 +113,7 @@ module TaskWriterResult =
         member __.Bind(m, f) = bind f m
         member __.Zero() = __.Return()
         member __.Source(x: Task<Writer<'w, Result<'a, 'b>>>) = x
+        member __.Source(x: Async<Writer<'w, Result<'a, 'b>>>) = x |> Async.StartAsTask
 
     let taskWriterResult = TaskWriterResultBuilder()
 
@@ -122,6 +123,7 @@ module TaskWriterResult =
             member __.Source(x: Result<'a, 'b>) = x |> TaskWriter.retn
             member __.Source(x: Writer<'w, 't>) = x |> Writer.map Ok |> Task.retn
             member __.Source(x: Task<'t>) = x |> Task.map WriterResult.retn
+            member __.Source(x: Async<'t>) = x |> Async.StartAsTask |> Task.map WriterResult.retn
 
     [<AutoOpen>]
     module TaskWriterResultBuilderExtensionsHighPriority =
@@ -129,3 +131,5 @@ module TaskWriterResult =
             member __.Source(x: Writer<'w, Result<'a, 'b>>) = x |> Task.retn
             member __.Source(x: Task<Result<'a, 'b>>) = x |> Task.map Writer.retn
             member __.Source(x: Task<Writer<'w, 't>>) = x |> TaskWriter.map Result.retn
+            member __.Source(x: Async<Result<'a, 'b>>) = x |> Async.StartAsTask |> Task.map Writer.retn
+            member __.Source(x: Async<Writer<'w, 't>>) = x |> Async.StartAsTask |> TaskWriter.map Result.retn


### PR DESCRIPTION
These changes allow you to return a task or async synonymously within an `AsyncWriterResult` or `TaskWriterResult` CE. Fstoolkit has similar functionality for `TaskResult` and `AsyncResult`