### PR TITLE
Move bindError to AsyncResult and add to other modules

### DIFF
--- a/src/AsyncWriterResult/AsyncResult.fs
+++ b/src/AsyncWriterResult/AsyncResult.fs
@@ -1,0 +1,7 @@
+namespace AsyncWriterResult
+
+open FsToolkit.ErrorHandling
+
+[<RequireQualifiedAccess>]
+module AsyncResult =
+    let bindError f = Async.map (Result.bindError f)

--- a/src/AsyncWriterResult/AsyncWriter.fs
+++ b/src/AsyncWriterResult/AsyncWriter.fs
@@ -24,8 +24,6 @@ module AsyncWriter =
             return Writer <| fun () -> b, logsA @ logsB
         }
 
-    let bindError f = Async.map (Result.bindError f)
-
     let mapBind (binder: 'a -> Writer<'log, 'b>) (input: AsyncWriter<'log, 'a>) : AsyncWriter<'log, 'b> =
         input |> Async.map (fun x -> Writer.bind x binder)
 

--- a/src/AsyncWriterResult/AsyncWriterResult.fs
+++ b/src/AsyncWriterResult/AsyncWriterResult.fs
@@ -28,6 +28,8 @@ module AsyncWriterResult =
             | Error e -> return Writer <| fun () -> Error e, logs1
         }
 
+    let bindError f = AsyncWriter.map (Result.bindError f)
+
     let apply f m =
         async {
             let! uf = f

--- a/src/AsyncWriterResult/AsyncWriterResult.fsproj
+++ b/src/AsyncWriterResult/AsyncWriterResult.fsproj
@@ -14,8 +14,10 @@
     <Compile Include="WriterOp.fs" />
     <Compile Include="AsyncWriter.fs" />
     <Compile Include="AsyncWriterCE.fs" />
+    <Compile Include="AsyncResult.fs" />
     <Compile Include="TaskWriter.fs" />
     <Compile Include="TaskWriterCE.fs" />
+    <Compile Include="TaskResult.fs" />
     <Compile Include="WriterResult.fs" />
     <Compile Include="WriterResultCE.fs" />
     <Compile Include="WriterResultOp.fs" />

--- a/src/AsyncWriterResult/TaskResult.fs
+++ b/src/AsyncWriterResult/TaskResult.fs
@@ -1,0 +1,7 @@
+namespace AsyncWriterResult
+
+open FsToolkit.ErrorHandling
+
+[<RequireQualifiedAccess>]
+module TaskResult =
+    let bindError f = Task.map (Result.bindError f)

--- a/src/AsyncWriterResult/TaskWriter.fs
+++ b/src/AsyncWriterResult/TaskWriter.fs
@@ -1,6 +1,5 @@
 namespace AsyncWriterResult
 
-open System.Threading.Tasks
 open FsToolkit.ErrorHandling
 
 [<RequireQualifiedAccess>]
@@ -24,8 +23,6 @@ module TaskWriter =
 
             return Writer <| fun () -> b, logsA @ logsB
         }
-
-    let bindError f = Task.map (Result.bindError f)
 
     let mapBind (binder: 'a -> Writer<'log, 'b>) (input: TaskWriter<'log, 'a>) : TaskWriter<'log, 'b> =
         input |> Task.map (fun x -> Writer.bind x binder)

--- a/src/AsyncWriterResult/TaskWriterResult.fs
+++ b/src/AsyncWriterResult/TaskWriterResult.fs
@@ -27,6 +27,8 @@ module TaskWriterResult =
             | Error e -> return Writer <| fun () -> Error e, logs1
         }
 
+    let bindError f = TaskWriter.map (Result.bindError f)
+
     let apply f m =
         task {
             let! uf = f

--- a/src/AsyncWriterResult/WriterResult.fs
+++ b/src/AsyncWriterResult/WriterResult.fs
@@ -26,6 +26,8 @@ module WriterResult =
             Writer <| fun () -> b, logs1 @ logs2
         | Error e -> Writer <| fun () -> Error e, logs1
 
+    let bindError f = Writer.map (Result.bindError f)
+
     let apply f m =
         let r1, logs1 = Writer.run f
         let r2, logs2 = Writer.run m


### PR DESCRIPTION
`bindError` is currently in the AsyncWriter/TaskWriter modules, although it operates on AsyncResult/TaskResult, so should be in those modules instead.

This PR moves `bindError` to the correct modules, and adds `bindError` functions to similar modules operating on results