### PR TITLE
Update asyncWriterResult CE to support `For` and `If-Return`

### DIFF
--- a/src/AsyncWriterResult/AsyncWriterResultCE.fs
+++ b/src/AsyncWriterResult/AsyncWriterResultCE.fs
@@ -17,6 +17,13 @@ module AsyncWriterResultCE =
         member _.Delay(generator: unit -> Async<Writer<'log,Result<'ok, 'error>>>) : Async<Writer<'log,Result<'ok,'error>>> =
             async.Delay generator
 
+        member inline this.Combine
+            (
+                computation1: Async<Writer<'log, Result<unit, 'error>>>,
+                computation2: Async<Writer<'log, Result<'ok, 'error>>>
+            ) : Async<Writer<'log, Result<'ok, 'error>>> =
+            this.Bind (computation1, (fun () -> computation2))
+
         member inline _.TryFinally
             (computation: Async<Writer<'log,Result<'ok,'error>>>, [<InlineIfLambda>] compensation: unit -> unit)
             : Async<Writer<'log,Result<'ok,'error>>> =

--- a/src/AsyncWriterResult/AsyncWriterResultCE.fs
+++ b/src/AsyncWriterResult/AsyncWriterResultCE.fs
@@ -1,5 +1,6 @@
 namespace AsyncWriterResult
 
+open System
 open FsToolkit.ErrorHandling
 open System.Threading.Tasks
 
@@ -13,6 +14,43 @@ module AsyncWriterResultCE =
         member __.Zero() = __.Return()
         member __.BindReturn(x, f) = AsyncWriterResult.map f x
         member __.MergeSources(x, y) = AsyncWriterResult.zip x y
+        member _.Delay(generator: unit -> Async<Writer<'log,Result<'ok, 'error>>>) : Async<Writer<'log,Result<'ok,'error>>> =
+            async.Delay generator
+
+        member inline _.TryFinally
+            (computation: Async<Writer<'log,Result<'ok,'error>>>, [<InlineIfLambda>] compensation: unit -> unit)
+            : Async<Writer<'log,Result<'ok,'error>>> =
+            async.TryFinally(computation, compensation)
+
+        member this.While
+            (guard: unit -> bool, computation: Async<Writer<'log,Result<unit,'error>>>)
+            : Async<Writer<'log,Result<unit,'error>>> =
+            if not (guard ()) then
+                this.Zero()
+            else
+                this.Bind(computation, (fun () -> this.While(guard, computation)))
+
+        member inline this.Using
+            (
+                resource: 'disposable :> IDisposable,
+                [<InlineIfLambda>] binder: 'disposable -> Async<Writer<'log,Result<unit,'error>>>
+            ) : Async<Writer<'log,Result<unit,'error>>> =
+            this.TryFinally(
+                (binder resource),
+                (fun () ->
+                    if not (obj.ReferenceEquals(resource, null)) then
+                        resource.Dispose()
+                )
+            )
+
+        member inline this.For
+            (sequence: #seq<'input>, binder: 'input -> Async<Writer<'log, Result<unit,'error>>>)
+            : Async<Writer<'log,Result<unit, 'error>>> =
+            this.Using(
+                sequence.GetEnumerator(),
+                fun enum -> this.While(enum.MoveNext, this.Delay(fun () -> binder enum.Current))
+            )
+        member __.Source(s: #seq<_>) : #seq<_> = s
         member __.Source(x: Async<Writer<'w, Result<'a, 'b>>>) = x
         member __.Source(x: Task<Writer<'w, Result<'a, 'b>>>) = x |> Async.AwaitTask
 

--- a/tests/AsyncWriterResult.UnitTests/AsyncWriterResultTests.fs
+++ b/tests/AsyncWriterResult.UnitTests/AsyncWriterResultTests.fs
@@ -28,6 +28,21 @@ let ceTests =
           |> ignore
 
           Expect.equal "" [1; 3; 4; 2] acc
+      }
+
+      test "can be used in a for loop" {
+          let aw =
+              asyncWriterResult {
+                  for i in [ 1; 2; 3; 4 ] do
+                        do! Writer.write i
+              }
+
+          let _, actualWritten =
+              aw
+              |> Async.RunSynchronously
+              |> Writer.run
+
+          Expect.equal "written" [ 1; 2; 3; 4 ] actualWritten
       } ]
 
 [<Tests>]

--- a/tests/AsyncWriterResult.UnitTests/AsyncWriterResultTests.fs
+++ b/tests/AsyncWriterResult.UnitTests/AsyncWriterResultTests.fs
@@ -34,7 +34,7 @@ let ceTests =
           let aw =
               asyncWriterResult {
                   for i in [ 1; 2; 3; 4 ] do
-                        do! Writer.write i
+                      do! Writer.write i
               }
 
           let _, actualWritten =
@@ -43,6 +43,22 @@ let ceTests =
               |> Writer.run
 
           Expect.equal "written" [ 1; 2; 3; 4 ] actualWritten
+      }
+      
+      test "can use if-return" {
+          let aw x =
+              asyncWriterResult {
+                  if x then
+                      do! Writer.write 1
+                  return Writer.write 0
+              }
+
+          let _, actualWritten =
+              aw true
+              |> Async.RunSynchronously
+              |> Writer.run
+
+          Expect.equal "written" [ 1 ] actualWritten
       } ]
 
 [<Tests>]


### PR DESCRIPTION
I would like to propose to add support for `For` CE member so we can use  `for loops` e.g.
```fsharp
asyncWriterResult {
    for i in [ 1; 2; 3; 4 ] do
        do! Writer.write i
    }

asyncWriterResult {
    if x then
        do! Writer.write 1
    return Writer.write 0
}
```